### PR TITLE
bugfix: Ajuste que corrige el  color de las tarjetas de historial.

### DIFF
--- a/src/app/historial/historial.component.scss
+++ b/src/app/historial/historial.component.scss
@@ -10,7 +10,7 @@
   flex-direction: row;
   align-items: center;
   padding: 0;
-  background-color: #69CB9C;
+  background-color: #F2F2F2;
   border-radius: 12px;
   min-height: 150px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
**Antes:**
![image](https://github.com/user-attachments/assets/70cb8b6a-7fa4-49d8-8a6e-84895df2072a)

**Ahora con el fix**
![image](https://github.com/user-attachments/assets/878b3b18-5709-4f1d-bbdc-f0c2ccd28ddb)
